### PR TITLE
Introduce stopwatches to measure execution times

### DIFF
--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -82,6 +82,7 @@ ${SESync_INCLUDE_DIR}/SESync_utils.h
 ${SESync_INCLUDE_DIR}/SESyncProblem.h
 ${SESync_INCLUDE_DIR}/SESyncRTRNewton.h
 ${SESync_INCLUDE_DIR}/SESync.h
+${SESync_INCLUDE_DIR}/stopwatch.h
 )
 
 set(SESync_SRCS

--- a/C++/SE-Sync/include/SESync.h
+++ b/C++/SE-Sync/include/SESync.h
@@ -171,6 +171,9 @@ struct SESyncResult {
    * algorithm at which the returned function values were obtained */
   std::vector<double> elapsed_optimization_times;
 
+  /** A collection with all measured times in the algorithm */
+  std::map<std::string,double> times;
+
   /** The optimal translational estimates corresponding to the rotational
    * estimate Rhat */
   Matrix that;

--- a/C++/SE-Sync/include/stopwatch.h
+++ b/C++/SE-Sync/include/stopwatch.h
@@ -1,0 +1,107 @@
+/** This file provides a convenient functional interface to the SESync algorithm
+*
+* jbriales 09 Sept 2017
+*/
+
+#ifndef _STOPWATCH_H_
+#define _STOPWATCH_H_
+
+#include <chrono>
+#include <map>
+
+#include <string>
+#include <iostream>
+#include <fstream>
+
+namespace SESync
+{
+  namespace util
+  {
+
+    /** This class provides an intuitive and compact interface to measure
+     * execution time of sections of code */
+    class stopwatch
+    {
+    private:
+      std::chrono::time_point<std::chrono::high_resolution_clock> start_time;
+      std::chrono::duration<double> counter;
+      double elapsed_time;
+
+    public:
+      /** Begin counting time */
+      inline void start()
+      {
+        start_time = std::chrono::high_resolution_clock::now();
+      }
+
+      /** Store current elapsed time since start() */
+      inline void stop()
+      {
+        counter = std::chrono::high_resolution_clock::now() - start_time;
+        // elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(counter).count() / 1e3;
+        elapsed_time = counter.count();
+      }
+
+      /** Read elapsed time from start() until last stop() */
+      inline double time() const {return elapsed_time;}
+
+      /** Formated verbose output */
+      inline void print()
+      {
+        std::cout << "elapsed computation time: "
+                  << elapsed_time << " seconds"
+                  << std::endl;
+      }
+    };
+
+    /** This class provides the ability to define and handle multiple stopwatches
+     * simultaneously in a neat way */
+    class stopwatch_collection
+    {
+    private:
+      /** Map of all name-stopwatch* pairs defined in the collection */
+      std::map<std::string,stopwatch*> watches;
+
+    public:
+      stopwatch_collection(){}
+      ~stopwatch_collection()
+      {
+        // Deallocate memory for all created watches
+        for(auto ptr = watches.begin(); ptr != watches.end(); ptr++)
+          delete ptr->second;
+      }
+
+      /** Create new stopwatch in the collection.
+       * The pointer to the new watch is returned. */
+      inline stopwatch* add(const std::string& name)
+      {
+        stopwatch* ptr = new stopwatch();
+        watches[name] = ptr;
+        return ptr;
+      }
+
+      /** Look for watch by name and return a pointer to it */
+      inline stopwatch* operator[](const std::string& name)
+      {
+        return watches[name];
+      }
+
+      /** Returns a map which contains only the measured times */
+      std::map<std::string,double> readTimes()
+      {
+        std::map<std::string,double> timesMap;
+        for(auto ptr = this->watches.begin(); ptr != this->watches.end(); ptr++)
+        {
+          const std::string& name = ptr->first;
+          const stopwatch* sw = ptr->second;
+          // Allocate elements in the name-times map
+          timesMap[name] = sw->time();
+        }
+        return timesMap;
+      }
+    };
+
+  } /* namespace util */
+} /* namespace SESync */
+
+#endif /* _STOPWATCH_H_ */


### PR DESCRIPTION
We introduce the stopwatch and stopwatch_collection classes
as a convenient way to measure and save execution times in
a compact, ordered and flexible way:
- The refactoring of chrono-related code into its own class
  makes the code more compact and with clearer syntax
- The dynamic character of stopwatch_collection allows us
  to easily store all the measured times into the results
  for later comparison and benchmarking
- Declaring all the related variables into the corresponding classes
  reduces the number of variables seen in execution,
  making debugging easier

Note the stopwatch_collection::readTimes() method,
which allows us to store all measured times
as a list of "tagged" times (a string-double map).