### PR TITLE
Interactive visualization module.

### DIFF
--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -29,6 +29,8 @@ set(ENABLE_VECTORIZATION OFF CACHE BOOL "Enable vectorized instruction sets (SIM
 set(ENABLE_OPENMP ON CACHE BOOL "Enable OpenMP (if available)")
 # Enable code profiling using gperftools
 set(ENABLE_PROFILING OFF CACHE BOOL "Enable code profiling using gperftools")
+# Enable visualization module.
+set(ENABLE_VISUALIZATION OFF CACHE BOOL "Enable visualization module.")
 
 # Add the .cmake files that ship with Eigen3 to the CMake module path (useful for finding other stuff)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/Eigen/cmake" CACHE STRING "The CMake module path used for this project")
@@ -41,6 +43,10 @@ endif()
 if(${ENABLE_PROFILING})
 message(STATUS "Enabling code profiling using Google Performance Tools")
 set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} -lprofiler)
+endif()
+
+if(${ENABLE_VISUALIZATION})
+  find_package(Pangolin REQUIRED)
 endif()
 
 message(STATUS "")
@@ -111,11 +117,23 @@ ${SESync_SOURCE_DIR}/SESyncProblem.cpp
 ${SESync_SOURCE_DIR}/SESync.cpp
 )
 
+# If visualization is enabled, make sure to include corresponding files.
+if(${ENABLE_VISUALIZATION})
+  list(APPEND SESync_HDRS
+    ${SESync_HDR_DIR}/SESyncVisualizer.h)
+  list(APPEND SESync_SRCS
+    ${SESync_SOURCE_DIR}/SESyncVisualizer.cpp)
+endif()
+
 # Build the SE-Sync library
 add_library(${PROJECT_NAME} SHARED ${SESync_HDRS} ${SESync_SRCS})
 target_include_directories(${PROJECT_NAME} PRIVATE ${SESync_PRIVATE_INCLUDES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${SESync_INCLUDES})
 target_link_libraries(${PROJECT_NAME} Optimization ${BLAS_LIBRARIES} ${CHOLMOD_LIBRARIES} ${SPQR_LIBRARIES} ${M} ${LAPACK})
+
+if(${ENABLE_VISUALIZATION})
+  target_link_libraries(${PROJECT_NAME} ${Pangolin_LIBRARIES})
+endif()
 
 if(OPENMP_FOUND)
 # Add additional compilation flags to enable OpenMP support

--- a/C++/CMakeLists.txt
+++ b/C++/CMakeLists.txt
@@ -117,13 +117,6 @@ ${SESync_SOURCE_DIR}/SESyncProblem.cpp
 ${SESync_SOURCE_DIR}/SESync.cpp
 )
 
-# If visualization is enabled, make sure to include corresponding files.
-if(${ENABLE_VISUALIZATION})
-  list(APPEND SESync_HDRS
-    ${SESync_HDR_DIR}/SESyncVisualizer.h)
-  list(APPEND SESync_SRCS
-    ${SESync_SOURCE_DIR}/SESyncVisualizer.cpp)
-endif()
 
 # Build the SE-Sync library
 add_library(${PROJECT_NAME} SHARED ${SESync_HDRS} ${SESync_SRCS})
@@ -131,16 +124,27 @@ target_include_directories(${PROJECT_NAME} PRIVATE ${SESync_PRIVATE_INCLUDES})
 target_include_directories(${PROJECT_NAME} PUBLIC ${SESync_INCLUDES})
 target_link_libraries(${PROJECT_NAME} Optimization ${BLAS_LIBRARIES} ${CHOLMOD_LIBRARIES} ${SPQR_LIBRARIES} ${M} ${LAPACK})
 
-if(${ENABLE_VISUALIZATION})
-  target_link_libraries(${PROJECT_NAME} ${Pangolin_LIBRARIES})
-endif()
-
 if(OPENMP_FOUND)
 # Add additional compilation flags to enable OpenMP support
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS ${OpenMP_CXX_FLAGS})
 set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-fopenmp")
 target_link_libraries(${PROJECT_NAME})
 endif()
+
+
+# SE-SYNC VISUALIZATION PROJECT
+
+# If visualization is enabled, build library.
+if(${ENABLE_VISUALIZATION})
+  set(SESyncViz_HDRS ${SESync_HDR_DIR}/SESyncVisualizer.h)
+  set(SESyncViz_SRCS ${SESync_SOURCE_DIR}/SESyncVisualizer.cpp)
+
+  add_library(SESyncViz SHARED ${SESyncViz_HDRS} ${SESyncViz_SRCS})
+  target_include_directories(SESyncViz PUBLIC ${SESync_INCLUDE_DIR})
+  target_link_libraries(SESyncViz ${PROJECT_NAME} ${Pangolin_LIBRARIES})
+endif()
+
+
 
 # BUILD EXAMPLE DRIVER
 add_subdirectory(examples)
@@ -153,3 +157,14 @@ export(PACKAGE ${PROJECT_NAME})
 # Create a configuration file for this project, so that it can be imported by other CMake projects
 export(TARGETS ${PROJECT_NAME} Optimization FILE ${PROJECT_NAME}Config.cmake)
 
+
+# EXPORT SE-SYNC VISUALIZATION LIBRARY
+
+if(${ENABLE_VISUALIZATION})
+# Add add entry for this project into CMake's package registry, so that this
+# project can be found by other CMake projects
+export(PACKAGE SESyncViz)
+# Create a configuration file for this project, so that it can be imported by
+# other CMake projects
+export(TARGETS SESyncViz FILE SESyncVizConfig.cmake)
+endif()

--- a/C++/SE-Sync/include/SESync/SESyncVisualizer.h
+++ b/C++/SE-Sync/include/SESync/SESyncVisualizer.h
@@ -24,6 +24,12 @@ namespace SESync {
 typedef std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>>
     Trajectory3;
 
+struct VisualizationOpts {
+  std::string img_name = "SE-Sync-Iter";   ///< Name for output screenshots.
+  std::string img_dir = "SE-Sync-Images";  ///< Output directory name.
+  double delay = 0.5;                      ///< Delay between iterates [s].
+};
+
 /**
  * @class SESyncVisualizer
  * @brief Class for wrapping OpenGL and Pangoling to visualize in SESync in 3D.
@@ -36,9 +42,10 @@ class SESyncVisualizer {
    * @param measurements  Vector with relative pose measurements.
    * @param options       Structure with SE-Sync initialization options.
    */
-  explicit SESyncVisualizer(const size_t num_poses,
-                            const measurements_t &measurements,
-                            const SESyncOpts &options);
+  explicit SESyncVisualizer(
+      const size_t num_poses, const measurements_t &measurements,
+      const SESyncOpts &options,
+      const VisualizationOpts &vopts = VisualizationOpts());
 
   /**
    * @brief Default destructor.
@@ -104,6 +111,7 @@ class SESyncVisualizer {
   size_t num_poses_;             ///< Total number of poses.
   size_t num_iters_;             ///< Total number of iterates.
   size_t dim_;                   ///< Dimension of the problem.
+  VisualizationOpts vopts_;      ///< Visualization related parameters.
   SESyncOpts options_;           ///< Initial description of problem.
   SESyncResult result_;          ///< Bundle of magic is all here.
   std::shared_ptr<SESyncProblem> problem_;  ///< Problem instance.

--- a/C++/SE-Sync/include/SESync/SESyncVisualizer.h
+++ b/C++/SE-Sync/include/SESync/SESyncVisualizer.h
@@ -1,0 +1,94 @@
+/**
+ * @file SESyncVisualizer.h
+ * @brief Simple 3D visualization tool based on Pangolin.
+ * @author Tonio Teran, David Rosen, {teran,dmrosen}@mit.edu
+ * Copyright (C) 2016 - 2020 by David M. Rosen (dmrosen@mit.edu)
+ */
+
+#pragma once
+
+#include <pangolin/pangolin.h>
+#include <pangolin/scene/axis.h>
+#include <pangolin/scene/scenehandler.h>
+
+#include <Eigen/Dense>
+#include <tuple>
+#include <vector>
+
+#include "SESync/SESync.h"
+
+namespace SESync {
+
+/// Trajectory consisiting of vector of Eigen-aligned 4x4 SE(3) matrices.
+typedef std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>>
+    Trajectory3;
+/// 3D Pose with axes length (1st double) and line width (2nd double) for viz.
+typedef std::tuple<Eigen::Matrix4d, double, double> VizPose;
+
+/**
+ * @class SESyncVisualizer
+ * @brief Class for wrapping OpenGL and Pangoling to visualize in 3D.
+ */
+class SESyncVisualizer {
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  /**
+   * @brief Default constructor.
+   * @param result  Structure with SE-Sync results.
+   */
+  explicit SESyncVisualizer(const measurements_t &measurements,
+                            const SESyncOpts &options);
+
+  /**
+   * @brief Default destructor.
+   */
+  ~SESyncVisualizer();
+
+  /**
+   * @brief Main visualization for Simple3dWorld that does all the drawing.
+   */
+  void RenderWorld();
+
+  /**
+   * @brief Add a visualization pose element.
+   * @param[in] vpose   Visualization tuple with pose, axes length, and width.
+   */
+  void AddVizPose(const VizPose &vpose) { vposes_.push_back(vpose); }
+
+  /**
+   * @brief Add a visualization pose element.
+   * @param[in] pose     3D pose of triad to visualize.
+   * @param[in] length   Length of the pose axes.
+   * @param[in] width    Width of the pose axes..
+   */
+  void AddVizPose(const Eigen::Matrix4d &pose, const double length,
+                  const double width) {
+    AddVizPose(std::make_tuple(pose, length, width));
+  }
+
+private:
+  /**
+   * @brief Renders the trajectory as a sequence of triads.
+   * @param[in] trajectory Eigen-aligned vector of 3D poses.
+   */
+  void DrawTrajectory(const Trajectory3 &trajectory,
+                      const double axesLength = 0.2) const;
+
+  // Manually-modifiable variables.
+  std::vector<VizPose> vposes_;  ///< Manually added poses to visualize.
+  std::vector<Matrix> iterates_; ///< Rounded iterates for visualization.
+
+  Trajectory3 est_; ///< Current state estimate trajectory.
+  Trajectory3 tgt_; ///< Current trajectory estimate for the target.
+
+  float w_ = 1200.0f; ///< Width of the screen [px].
+  float h_ = 800.0f;  ///< Heigh of the screen [px].
+  float f_ = 300.0f;  ///< Focal distance of the visualization camera [px].
+
+  measurements_t measurements_;            ///< Relative pose measurements data.
+  SESyncOpts options_;                     ///< Initial description of problem.
+  SESyncResult result_;                    ///< Bundle of magic is all here.
+  std::shared_ptr<SESyncProblem> problem_; ///< Problem instance.
+};
+
+} // namespace SESync

--- a/C++/SE-Sync/include/SESync/SESyncVisualizer.h
+++ b/C++/SE-Sync/include/SESync/SESyncVisualizer.h
@@ -73,9 +73,18 @@ private:
    */
   Matrix AnchorSolution(const Matrix &xhat) const;
 
+  /**
+   * @brief Rotates a solution such that the first pose had identity R.
+   * @param[in] xhat  Solution matrix with [translations|Rotations].
+   * @return Solution matrix with R0 = I.
+   */
+  Matrix RotateSolution(const Matrix &xhat) const;
+
   std::vector<Matrix> iterates_;       ///< Rounded iterates for visualization.
-  std::vector<Trajectory3> solutions_; ///< Parsed solutions.
-  std::vector<std::vector<Eigen::Vector3d>> lcs_; ///< Loop closures.
+  std::vector<Trajectory3> solutions_; ///< Parsed solutions, raw.
+  std::vector<Trajectory3> solnspind_; ///< Parsed solutions, pinned and rot'd.
+  std::vector<std::vector<Eigen::Vector3d>> lcs_; ///< Loop closures, natural.
+  std::vector<std::vector<Eigen::Vector3d>> lcspind_; ///< Loop closures, rot'd.
 
   float w_ = 1200.0f; ///< Width of the screen [px].
   float h_ = 800.0f;  ///< Heigh of the screen [px].

--- a/C++/SE-Sync/include/SESync/SESyncVisualizer.h
+++ b/C++/SE-Sync/include/SESync/SESyncVisualizer.h
@@ -63,10 +63,11 @@ class SESyncVisualizer {
    * @param[in] trajectory  Eigen-aligned vector of 3D poses.
    * @param[in] lcs         Vector of 3D position pairs for loop-closing lines.
    * @param[in] marker      Whether to draw point markers or not.
+   * @param[in] loops       Whether to draw loop closing lines or not.
    */
   void DrawIterate(const Trajectory3 &trajectory,
-                   const std::vector<Eigen::Vector3d> &lcs,
-                   const bool marker) const;
+                   const std::vector<Eigen::Vector3d> &lcs, const bool marker,
+                   const bool loops) const;
 
   /**
    * @brief Parse an Xhat solution matrix into individual poses.

--- a/C++/SE-Sync/include/SESync/SESyncVisualizer.h
+++ b/C++/SE-Sync/include/SESync/SESyncVisualizer.h
@@ -25,14 +25,16 @@ typedef std::vector<Eigen::Matrix4d, Eigen::aligned_allocator<Eigen::Matrix4d>>
 
 /**
  * @class SESyncVisualizer
- * @brief Class for wrapping OpenGL and Pangoling to visualize in 3D.
+ * @brief Class for wrapping OpenGL and Pangoling to visualize in SESync in 3D.
  */
 class SESyncVisualizer {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   /**
    * @brief Default constructor.
-   * @param result  Structure with SE-Sync results.
+   * @param num_poses     Total number of poses in the problem.
+   * @param measurements  Vector with relative pose measurements.
+   * @param options       Structure with SE-Sync initialization options.
    */
   explicit SESyncVisualizer(const size_t num_poses,
                             const measurements_t &measurements,
@@ -44,17 +46,18 @@ public:
   ~SESyncVisualizer();
 
   /**
-   * @brief Main visualization for Simple3dWorld that does all the drawing.
+   * @brief Main visualization for enjoying the synchronization process.
    */
-  void RenderWorld();
+  void RenderSynchronization();
 
 private:
   /**
-   * @brief Renders the trajectory as a sequence of triads.
-   * @param[in] trajectory Eigen-aligned vector of 3D poses.
+   * @brief Renders the solution as points and lines.
+   * @param[in] trajectory  Eigen-aligned vector of 3D poses.
+   * @param[in] lcs         Vector of 3D position pairs for loop-closing lines.
    */
-  void DrawTrajectory(const Trajectory3 &trajectory,
-                      const double axesLength = 0.2) const;
+  void DrawIterate(const Trajectory3 &trajectory,
+                   const std::vector<Eigen::Vector3d> &lcs) const;
 
   /**
    * @brief Parse an Xhat solution matrix into individual poses.
@@ -72,9 +75,7 @@ private:
 
   std::vector<Matrix> iterates_;       ///< Rounded iterates for visualization.
   std::vector<Trajectory3> solutions_; ///< Parsed solutions.
-
-  Trajectory3 est_; ///< Current state estimate trajectory.
-  Trajectory3 tgt_; ///< Current trajectory estimate for the target.
+  std::vector<std::vector<Eigen::Vector3d>> lcs_; ///< Loop closures.
 
   float w_ = 1200.0f; ///< Width of the screen [px].
   float h_ = 800.0f;  ///< Heigh of the screen [px].

--- a/C++/SE-Sync/src/SESyncVisualizer.cpp
+++ b/C++/SE-Sync/src/SESyncVisualizer.cpp
@@ -22,10 +22,11 @@ SESyncVisualizer::SESyncVisualizer(const size_t num_poses,
       options_.preconditioner,
       options_.reg_Cholesky_precon_max_condition_number);
 
-  // Solve (Empty initialization).
-  result_ = SESync(*problem_, options_, /*Y0 = */ Matrix());
+  // Solve.
+  result_ = SESync(*problem_, options_);
 
   // Round all iterates using approriate rank.
+  std::cout << "Rounding iterates..." << std::endl;
   std::vector<std::vector<Matrix>> iterates = result_.iterates;
   size_t rank_counter = options_.r0;
   for (size_t l = 0; l < iterates.size(); l++) {
@@ -40,8 +41,24 @@ SESyncVisualizer::SESyncVisualizer(const size_t num_poses,
   dim_ = result_.xhat.rows();
 
   // Parse all solutions into vectors of matrices.
+  std::cout << "Parsing rounded solutions..." << std::endl;
   for (const Matrix &xhat : iterates_) {
     solutions_.push_back(ParseXhatToVector(AnchorSolution(xhat)));
+    lcs_.push_back(std::vector<Eigen::Vector3d>()); // Empty.
+  }
+
+  // Detect loop closures for drawing.
+  std::cout << "Analyzing loop closures..." << std::endl;
+  size_t M = measurements_.size();
+  for (size_t m = 0; m < M; m++) {
+    int i = measurements_[m].i;
+    int j = measurements_[m].j;
+    if (std::abs(j - i) != 1) {
+      for (size_t v = 0; v < solutions_.size(); v++) {
+        lcs_[v].push_back(solutions_[v][i].block(0, 3, 3, 1)); // i-th position.
+        lcs_[v].push_back(solutions_[v][j].block(0, 3, 3, 1)); // j-th position.
+      }
+    }
   }
 }
 
@@ -49,7 +66,7 @@ SESyncVisualizer::SESyncVisualizer(const size_t num_poses,
 SESyncVisualizer::~SESyncVisualizer() {}
 
 /* *************************************************************************  */
-void SESyncVisualizer::RenderWorld() {
+void SESyncVisualizer::RenderSynchronization() {
   std::cout << "Starting the visualization thread." << std::endl;
   pangolin::CreateWindowAndBind("SE-Sync Super Official Viewer", w_, h_);
   glEnable(GL_DEPTH_TEST);
@@ -61,102 +78,80 @@ void SESyncVisualizer::RenderWorld() {
       proj,
       pangolin::ModelViewLookAt(1.0, 1.0, 1.0, 0.0, 0.0, 0.0, pangolin::AxisZ));
 
-  // Create the individual cameras for each view.
+  // Create the camera for the view.
   pangolin::View &d_cam = pangolin::CreateDisplay()
                               .SetBounds(0.0, 1.0, 0.0, 1.0)
                               .SetHandler(new pangolin::Handler3D(s_cam));
-  // Create the image viewer for either mono or stereo.
-  pangolin::View &left_cam =
-      pangolin::CreateDisplay().SetBounds(0.05, 0.3, 0.05, 0.5);
-  pangolin::View &right_cam =
-      pangolin::CreateDisplay().SetBounds(0.05, 0.3, 0.5, 0.95);
 
   // Real-time toggles using key presses.
-  bool show_z0 = true;
+  bool show_z0 = true; // For the XY-plane grid.
   pangolin::RegisterKeyPressCallback('z', [&]() { show_z0 = !show_z0; });
-
-  bool restart = false;
+  bool restart = false; // For restarting the visualization.
   pangolin::RegisterKeyPressCallback('r', [&]() { restart = !restart; });
 
-  // Manage the size of the points.
-  glPointSize(3.5); // Default is 1.
-  // Useful identity.
-  Eigen::Matrix4d I_4x4 = Eigen::Matrix4d::Identity();
-
+  // Book-keeping variables for advancing between iterates.
   auto clock = Stopwatch::tick();
-  double time = 0, dt = 0.5;
-  size_t counter = 0, pose_idx = 0, num_iters = solutions_.size();
+  double time = 0; // [s].
+  size_t counter = 0, soln_idx = 0, num_iters = solutions_.size();
+  double dt = 0.5; // The desired time between iterate visualization [s].
 
   while (!pangolin::ShouldQuit()) {
     // Clear screen and activate view to render into
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-    // ------------
-    // -- 2D plots.
-
-    // -----------
-    // -- 3D view.
     d_cam.Activate(s_cam);
-    // Background color.
-    glClearColor(0.9f, 0.9f, 0.9f, 0.0f);
-    // Default line width.
-    glLineWidth(1.0);
+    glClearColor(0.9f, 0.9f, 0.9f, 0.0f); // Background color.
 
-    DrawTrajectory(solutions_[pose_idx]);
+    DrawIterate(solutions_[soln_idx], lcs_[soln_idx]);
 
     s_cam.Apply();
     glColor3f(1.0, 1.0, 1.0);
-    if (show_z0)
-      pangolin::glDraw_z0(1.0, 2);
-    glLineWidth(7.5);
-    if (show_z0)
-      pangolin::glDrawAxis(I_4x4, 0.11);
-    glLineWidth(1.0);
+    if (show_z0) // Draw XY plane, if desired (toggle with 'z' key).
+      pangolin::glDraw_z0(10.0, 10);
 
     time = Stopwatch::tock(clock);
     counter++;
-    // std::cout << time << std::endl;
-    // std::cout << fmod(time, 3.0) << std::endl;
+    // Advance to next iterate at the desired time (`dt`).
     if (fmod(time, dt) < 1e-4 && counter > 100) {
-      std::cout << "SHOULD TRIGGER HERE!" << std::endl;
-      std::cout << "counter: " << counter << std::endl;
       counter = 0;
-      pose_idx++;
-      if (pose_idx == num_iters)
-        pose_idx = num_iters - 1;
-      std::cout << "pose idx: " << pose_idx << std::endl;
-      std::cout << "num poses: " << num_iters << std::endl;
+      soln_idx++;
+      if (soln_idx == num_iters)
+        soln_idx = num_iters - 1;
     }
 
-    if (restart) {
+    if (restart) { // Restart the iterates (toggle with 'r' key).
       restart = false;
-      pose_idx = 0;
+      soln_idx = 0;
     }
 
-    // Swap frames and Process Events
-    pangolin::FinishFrame();
+    pangolin::FinishFrame(); // Swap frames and process events.
   }
 }
 
 /* ************************************************************************** */
-void SESyncVisualizer::DrawTrajectory(const Trajectory3 &trajectory,
-                                      const double axesLength) const {
+void SESyncVisualizer::DrawIterate(
+    const Trajectory3 &trajectory,
+    const std::vector<Eigen::Vector3d> &lcs) const {
   std::vector<Eigen::Vector3d> positions;
 
-  // Draw all poses.
+  // Get all positions.
   for (const Eigen::Matrix4d &p : trajectory) {
     positions.push_back(p.block<3, 1>(0, 3));
   }
-  glLineWidth(3.0);
-  if (trajectory.size())
-    pangolin::glDrawAxis(trajectory.back(), axesLength);
 
   // Draw a line connecting all poses.
-  glColor4f(0.7, 0.7, 0.7, 0.1);
-  glLineWidth(3.0);
-  pangolin::glDrawLineStrip(positions);
+  glColor4f(0.2, 0.2, 1.0, 0.8);
   glLineWidth(1.0);
-  glColor3f(1.0, 1.0, 1.0);
+  pangolin::glDrawLineStrip(positions); // Odometry lines.
+  glPointSize(2.0);
+  glColor4f(0.6, 0.6, 1.0, 0.3);
+  pangolin::glDrawPoints(positions); // Position points.
+
+  // Draw loop closures.
+  glColor4f(0.7, 0.7, 1.0, 0.3);
+  glLineWidth(1.0);
+  pangolin::glDrawLines(lcs); // Loop-closing lines.
+  glLineWidth(1.0);
 }
 
 /* ************************************************************************** */

--- a/C++/SE-Sync/src/SESyncVisualizer.cpp
+++ b/C++/SE-Sync/src/SESyncVisualizer.cpp
@@ -1,0 +1,153 @@
+/**
+ * @file SESyncVisualizer.h
+ * @brief Simple 3D visualization tool based on Pangolin.
+ * @author Tonio Teran, David Rosen, {teran,dmrosen}@mit.edu
+ * Copyright (C) 2016 - 2020 by David M. Rosen (dmrosen@mit.edu)
+ */
+
+#include "SESync/SESyncVisualizer.h"
+
+#include <Eigen/StdVector>
+
+namespace SESync {
+
+/* *************************************************************************  */
+SESyncVisualizer::SESyncVisualizer(const measurements_t &measurements,
+                                   const SESyncOpts &options)
+    : measurements_(measurements), options_(options) {
+  // Build an SE-Sync problem.
+  problem_ = std::make_shared<SESyncProblem>(
+      measurements_, options_.formulation, options_.projection_factorization,
+      options_.preconditioner,
+      options_.reg_Cholesky_precon_max_condition_number);
+
+  // Solve (Empty initialization).
+  result_ = SESync(*problem_, options_, /*Y0 = */ Matrix());
+
+  // TEMP
+  std::vector<std::vector<Matrix>> iterates = result_.iterates;
+  std::cout << "Checking out the iterates." << std::endl;
+  std::cout << "Staircase levels: " << iterates.size() << std::endl;
+  size_t rank_counter = options_.r0;
+  for (size_t l = 0; l < iterates.size(); l++) {
+    problem_->set_relaxation_rank(rank_counter);
+    for (const Matrix &Y : iterates[l]) {
+      iterates_.push_back(problem_->round_solution(Y));
+      std::cout << "xhat: " << iterates_.back().rows() << "x"
+                << iterates_.back().cols() << std::endl;
+    }
+    std::cout << " - level " << rank_counter << ": " << iterates[l].size()
+              << std::endl;
+    rank_counter++;
+  }
+  Matrix Yopt = result_.Yopt;
+  std::cout << "Yopt dimensions: " << Yopt.rows() << "x" << Yopt.cols()
+            << std::endl;
+  std::cout << "Rank counter: " << rank_counter << std::endl;
+  std::cout << "recovered iterates: " << iterates_.size() << std::endl;
+  // TEMP
+
+  // Round all iterates using approriate rank.
+}
+
+/* *************************************************************************  */
+SESyncVisualizer::~SESyncVisualizer() {}
+
+/* *************************************************************************  */
+void SESyncVisualizer::RenderWorld() {
+  std::cout << "Starting the visualization thread." << std::endl;
+  pangolin::CreateWindowAndBind("SE-Sync Super Official Viewer", w_, h_);
+  glEnable(GL_DEPTH_TEST);
+
+  // Define Projection and initial ModelView matrix.
+  pangolin::OpenGlMatrix proj =
+      pangolin::ProjectionMatrix(w_, h_, f_, f_, w_ / 2.0, h_ / 2.0, 0.2, 1000);
+  pangolin::OpenGlRenderState s_cam(
+      proj,
+      pangolin::ModelViewLookAt(1.0, 1.0, 1.0, 0.0, 0.0, 0.0, pangolin::AxisZ));
+
+  // Create the individual cameras for each view.
+  pangolin::View &d_cam = pangolin::CreateDisplay()
+                              .SetBounds(0.0, 1.0, 0.0, 1.0)
+                              .SetHandler(new pangolin::Handler3D(s_cam));
+  // Create the image viewer for either mono or stereo.
+  pangolin::View &left_cam =
+      pangolin::CreateDisplay().SetBounds(0.05, 0.3, 0.05, 0.5);
+  pangolin::View &right_cam =
+      pangolin::CreateDisplay().SetBounds(0.05, 0.3, 0.5, 0.95);
+
+  // Real-time toggles using key presses.
+  bool show_z0 = true;
+  pangolin::RegisterKeyPressCallback('z', [&]() { show_z0 = !show_z0; });
+
+  bool show_gtsam = true;
+  pangolin::RegisterKeyPressCallback('g', [&]() { show_gtsam = !show_gtsam; });
+
+  bool show_manual = true;
+  pangolin::RegisterKeyPressCallback('m',
+                                     [&]() { show_manual = !show_manual; });
+
+  // Manage the size of the points.
+  glPointSize(3.5); // Default is 1.
+  // Useful identity.
+  Eigen::Matrix4d I_4x4 = Eigen::Matrix4d::Identity();
+
+  while (!pangolin::ShouldQuit()) {
+    // Clear screen and activate view to render into
+    glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+    // ------------
+    // -- 2D plots.
+
+    // -----------
+    // -- 3D view.
+    d_cam.Activate(s_cam);
+    // Background color.
+    glClearColor(0.9f, 0.9f, 0.9f, 0.0f);
+    // Default line width.
+    glLineWidth(1.0);
+
+    if (show_manual) {
+      for (const auto &vp : vposes_) {
+        glLineWidth(std::get<2>(vp));
+        pangolin::glDrawAxis(std::get<0>(vp), std::get<1>(vp));
+        glLineWidth(1.0);
+      }
+    }
+
+    s_cam.Apply();
+    glColor3f(1.0, 1.0, 1.0);
+    if (show_z0)
+      pangolin::glDraw_z0(1.0, 2);
+    glLineWidth(7.5);
+    if (show_z0)
+      pangolin::glDrawAxis(I_4x4, 0.11);
+    glLineWidth(1.0);
+
+    // Swap frames and Process Events
+    pangolin::FinishFrame();
+  }
+}
+
+/* ************************************************************************** */
+void SESyncVisualizer::DrawTrajectory(const Trajectory3 &trajectory,
+                                      const double axesLength) const {
+  std::vector<Eigen::Vector3d> positions;
+
+  // Draw all poses.
+  for (const Eigen::Matrix4d &p : trajectory) {
+    positions.push_back(p.block<3, 1>(0, 3));
+  }
+  glLineWidth(3.0);
+  if (trajectory.size())
+    pangolin::glDrawAxis(trajectory.back(), axesLength);
+
+  // Draw a line connecting all poses.
+  glColor4f(0.7, 0.7, 0.7, 0.1);
+  glLineWidth(3.0);
+  pangolin::glDrawLineStrip(positions);
+  glLineWidth(1.0);
+  glColor3f(1.0, 1.0, 1.0);
+}
+
+} // namespace SESync

--- a/C++/SE-Sync/src/SESyncVisualizer.cpp
+++ b/C++/SE-Sync/src/SESyncVisualizer.cpp
@@ -113,6 +113,8 @@ void SESyncVisualizer::RenderSynchronization() {
   pangolin::RegisterKeyPressCallback('b', [&]() { bkgnd = !bkgnd; });
   bool text = true;  // For rendering text information.
   pangolin::RegisterKeyPressCallback('t', [&]() { text = !text; });
+  bool loops = true;  // For toggling loop closing lines.
+  pangolin::RegisterKeyPressCallback('l', [&]() { loops = !loops; });
 
   bool take_screenshot = false;  // Auxiliary variable for saving frames.
   std::string mkdir_string = "mkdir -p " + vopts_.img_dir;
@@ -136,9 +138,9 @@ void SESyncVisualizer::RenderSynchronization() {
 
     // Show either the "natural" solution or the rotated and pinned one.
     if (pin) {  // Rotated and pinned.
-      DrawIterate(solnspind_[soln_idx], lcspind_[soln_idx], markers);
+      DrawIterate(solnspind_[soln_idx], lcspind_[soln_idx], markers, loops);
     } else {  // In parameter space.
-      DrawIterate(solutions_[soln_idx], lcs_[soln_idx], markers);
+      DrawIterate(solutions_[soln_idx], lcs_[soln_idx], markers, loops);
     }
 
     // Show iterate number and staircase level.
@@ -177,7 +179,7 @@ void SESyncVisualizer::RenderSynchronization() {
 /* ************************************************************************** */
 void SESyncVisualizer::DrawIterate(const Trajectory3 &trajectory,
                                    const std::vector<Eigen::Vector3d> &lcs,
-                                   const bool marker) const {
+                                   const bool marker, const bool loops) const {
   std::vector<Eigen::Vector3d> positions;
 
   // Get all positions.
@@ -196,7 +198,7 @@ void SESyncVisualizer::DrawIterate(const Trajectory3 &trajectory,
   // Draw loop closures.
   glColor4f(0.7, 0.7, 1.0, 0.3);
   glLineWidth(1.0);
-  pangolin::glDrawLines(lcs);  // Loop-closing lines.
+  if (loops) pangolin::glDrawLines(lcs);  // Loop-closing lines.
   glLineWidth(1.0);
 }
 

--- a/C++/examples/CMakeLists.txt
+++ b/C++/examples/CMakeLists.txt
@@ -8,3 +8,10 @@ endif()
 
 
 message(STATUS "Building main SE-Sync command-line executable in directory ${EXECUTABLE_OUTPUT_PATH}\n")
+
+
+# SE-Sync visualizer
+if(${ENABLE_VISUALIZATION})
+  add_executable(SE-SyncViz mainviz.cpp)
+  target_link_libraries(SE-SyncViz SESync)
+endif()

--- a/C++/examples/CMakeLists.txt
+++ b/C++/examples/CMakeLists.txt
@@ -13,5 +13,5 @@ message(STATUS "Building main SE-Sync command-line executable in directory ${EXE
 # SE-Sync visualizer
 if(${ENABLE_VISUALIZATION})
   add_executable(SE-SyncViz mainviz.cpp)
-  target_link_libraries(SE-SyncViz SESync)
+  target_link_libraries(SE-SyncViz SESync SESyncViz)
 endif()

--- a/C++/examples/CMakeLists.txt
+++ b/C++/examples/CMakeLists.txt
@@ -13,5 +13,5 @@ message(STATUS "Building main SE-Sync command-line executable in directory ${EXE
 # SE-Sync visualizer
 if(${ENABLE_VISUALIZATION})
   add_executable(SE-SyncViz mainviz.cpp)
-  target_link_libraries(SE-SyncViz SESync SESyncViz)
+  target_link_libraries(SE-SyncViz SESync SESyncViz stdc++fs)
 endif()

--- a/C++/examples/mainviz.cpp
+++ b/C++/examples/mainviz.cpp
@@ -1,0 +1,36 @@
+#include "SESync/SESync.h"
+#include "SESync/SESyncVisualizer.h"
+#include "SESync/SESync_utils.h"
+
+using namespace std;
+using namespace SESync;
+
+bool write_poses = false;
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    cout << "Usage: " << argv[0] << " [input .g2o file]" << endl;
+    exit(1);
+  }
+
+  size_t num_poses;
+  measurements_t measurements = read_g2o_file(argv[1], num_poses);
+  cout << "Loaded " << measurements.size() << " measurements between "
+       << num_poses << " poses from file " << argv[1] << endl
+       << endl;
+  if (measurements.size() == 0) {
+    cout << "Error: No measurements were read!"
+         << " Are you sure the file exists?" << endl;
+    exit(1);
+  }
+
+  SESyncOpts opts;
+  opts.verbose = true; // Print output to stdout
+  opts.num_threads = 4;
+  opts.initialization = Initialization::Random; // Make it interesting.
+  opts.log_iterates = true; // Want them for visualization!!!
+
+  // Run SE-Sync, and launch the visualization magic.
+  SESyncVisualizer viz(num_poses, measurements, opts);
+  viz.RenderWorld();
+}

--- a/C++/examples/mainviz.cpp
+++ b/C++/examples/mainviz.cpp
@@ -1,3 +1,6 @@
+#include <experimental/filesystem>
+#include <iostream>
+
 #include "SESync/SESync.h"
 #include "SESync/SESyncVisualizer.h"
 #include "SESync/SESync_utils.h"
@@ -25,12 +28,18 @@ int main(int argc, char **argv) {
   }
 
   SESyncOpts opts;
-  opts.verbose = true; // Print output to stdout
+  opts.verbose = true;  // Print output to stdout
   opts.num_threads = 4;
-  opts.initialization = Initialization::Random; // Make it interesting.
-  opts.log_iterates = true; // Want them for visualization!!!
+  opts.initialization = Initialization::Random;  // Make it interesting.
+
+  VisualizationOpts vopts;
+  vopts.delay = 0.1;  // [s]
+  vopts.img_name = "custom-img-name";
+  vopts.img_dir =
+      "sesync-iters-" +
+      std::string(std::experimental::filesystem::path(argv[1]).filename());
 
   // Run SE-Sync, and launch the visualization magic.
-  SESyncVisualizer viz(num_poses, measurements, opts);
+  SESyncVisualizer viz(num_poses, measurements, opts, vopts);
   viz.RenderSynchronization();
 }

--- a/C++/examples/mainviz.cpp
+++ b/C++/examples/mainviz.cpp
@@ -32,5 +32,5 @@ int main(int argc, char **argv) {
 
   // Run SE-Sync, and launch the visualization magic.
   SESyncVisualizer viz(num_poses, measurements, opts);
-  viz.RenderWorld();
+  viz.RenderSynchronization();
 }


### PR DESCRIPTION
Pangolin-based visualization module with the following features:

- Render the intermediate optimization process iterates either transformed to the origin or the "natural" evolution through the parameter space.
  - Toggle between options using the`p` key (as in pinned).
- Display text with iterate number and corresponding staircase level from which the iterate was rounded.
  - Toggle between hiding or showing text using the `t` key (as in text).
- Render either using a white or a black background.
  - Toggle between background options using the `b` key (as in background).
- Output a series of `.png` screenshots with the rendered iterates as `SE-Sync-Iter-XX.png`.
  - To save a full run, press the `s` key (as in save).
- Restart the iterates at any time to visualize again.
  - To do so, press the `r` key (as in restart).

![out](https://user-images.githubusercontent.com/27132241/96836609-37523280-1413-11eb-9d70-ddc3527877c5.gif)
